### PR TITLE
Capture errors and total test time. 

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -93,6 +93,7 @@ function process_junit_xml( $xml_string )
 		'tests' => (string) $project['tests'],
 		'failures' => (string) $project['failures'],
 		'errors' => (string) $project['errors'],
+		'time' => (string) $project['time'],
 	);
 
 	$results['testsuites'] = array();

--- a/functions.php
+++ b/functions.php
@@ -97,6 +97,8 @@ function process_junit_xml( $xml_string )
 
 	$results['testsuites'] = array();
 	foreach ( $project->testsuite as $testsuite ) {
+		// Handle nested testsuites like tests with data providers.
+		$testsuite = isset( $testsuite->testsuite ) ? $testsuite->testsuite : $testsuite;
 		$results['testsuites'][ (string) $testsuite['name'] ] = array(
 			'name' => (string) $testsuite['name'],
 			'tests' => (string) $testsuite['tests'],
@@ -105,11 +107,14 @@ function process_junit_xml( $xml_string )
 		);
 		$results['testsuites'][ (string) $testsuite['name'] ]['testcases'] = array();
 		foreach ( $testsuite->testcase as $testcase ) {
-			if ( isset( $testcase->failure ) ) {
-				$results['testsuites'][ (string) $testsuite['name'] ]['testcases'][ (string) $testcase['name'] ] = array(
-					'name' => (string) $testcase['name'],
-					'failure' => (string) $testcase->failure,
-				);
+			// Capture both failure and error children.
+			foreach ( array( 'failure', 'error') as $key ) {
+				if ( isset( $testcase->{$key} ) ) {
+					$results['testsuites'][ (string) $testsuite['name'] ]['testcases'][ (string) $testcase['name'] ] = array(
+						'name' => (string) $testcase['name'],
+						$key => (string) $testcase->{$key},
+					);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When a dataprovider is used phpunit produces an extra nested testsuite that looks like this: 

```XML
<testsuites>
  <testsuite name="" tests="562" assertions="1883" failures="105" errors="21" time="21.991066">
    <testsuite name="Tests_Canonical" file="/home/public/test/tests/phpunit/tests/canonical.php" tests="54" assertions="66" failures="0" errors="0" time="1.144615">
      <testsuite name="Tests_Canonical::test_canonical" tests="54" assertions="66" failures="0" errors="0" time="1.144615">
        <testcase name="test_canonical with data set #0" assertions="1" time="0.020822"/>
```

Instead of: 

```XML
<testsuites>
  <testsuite name="" tests="562" assertions="1883" failures="105" errors="21" time="21.991066">
    <testsuite name="Tests_Query_VerbosePageRules" file="/home/public/test/tests/phpunit/tests/query/verboseRewriteRules.php" tests="83" assertions="586" failures="6" errors="4" time="4.471400">
      <testcase name="test_home" class="Tests_Query_VerbosePageRules" file="/home/public/test/tests/phpunit/tests/query/verboseRewriteRules.php" line="30" assertions="2" time="0.022736">
```


Resolves #37. 
Resolves #28.

Example JSON dataset containing failures, errors, the time, and tests with data providers: 

```JavaScript
{
	"tests": "562",
	"failures": "105",
	"errors": "21",
	"time": "21.991066",
	"testsuites": {
		"Tests_Canonical::test_canonical": {
			"name": "Tests_Canonical::test_canonical",
			"tests": "54",
			"failures": "0",
			"errors": "0",
			"testcases": []
		},
		"Tests_Canonical_CustomRules::test": {
			"name": "Tests_Canonical_CustomRules::test",
			"tests": "2",
			"failures": "0",
			"errors": "0",
			"testcases": []
		},
		"Tests_Canonical_PageOnFront::test": {
			"name": "Tests_Canonical_PageOnFront::test",
			"tests": "8",
			"failures": "3",
			"errors": "0",
			"testcases": {
				"test with data set #4": {
					"name": "test with data set #4",
					"failure": "Tests_Canonical_PageOnFront::test with data set #4 ('\/front-page\/', '\/')\nFailed asserting that two strings are equal.\n--- Expected\n+++ Actual\n@@ @@\n-'\/'\n+'\/front-page\/'\n\n\/home\/public\/test\/tests\/phpunit\/includes\/testcase-canonical.php:178\n\/home\/public\/test\/tests\/phpunit\/tests\/canonical\/pageOnFront.php:22\n"
				},
				"test with data set #5": {
					"name": "test with data set #5",
					"failure": "Tests_Canonical_PageOnFront::test with data set #5 ('\/front-page\/2\/', '\/page\/2\/')\nFailed asserting that two strings are equal.\n--- Expected\n+++ Actual\n@@ @@\n-'\/page\/2\/'\n+'\/front-page\/2\/'\n\n\/home\/public\/test\/tests\/phpunit\/includes\/testcase-canonical.php:178\n\/home\/public\/test\/tests\/phpunit\/tests\/canonical\/pageOnFront.php:22\n"
				},
				"test with data set #6": {
					"name": "test with data set #6",
					"failure": "Tests_Canonical_PageOnFront::test with data set #6 ('\/front-page\/?page=2', '\/page\/2\/')\nFailed asserting that two strings are equal.\n--- Expected\n+++ Actual\n@@ @@\n-'\/page\/2\/'\n+'\/front-page\/2\/'\n\n\/home\/public\/test\/tests\/phpunit\/includes\/testcase-canonical.php:178\n\/home\/public\/test\/tests\/phpunit\/tests\/canonical\/pageOnFront.php:22\n"
				}
			}
		},
		"Tests_Canonical_Paged": {
			"name": "Tests_Canonical_Paged",
			"tests": "1",
			"failures": "0",
			"errors": "0",
			"testcases": []
		},
		"Tests_Post_GetPosts": {
			"name": "Tests_Post_GetPosts",
			"tests": "6",
			"failures": "3",
			"errors": "0",
			"testcases": {
				"test_offset_non_0_should_be_respected": {
					"name": "test_offset_non_0_should_be_respected",
					"failure": "Tests_Post_GetPosts::test_offset_non_0_should_be_respected\nFailed asserting that Array &0 (\n    0 => 696\n) is identical to Array &0 (\n    0 => 699\n).\n\n\/home\/public\/test\/tests\/phpunit\/tests\/post\/getPosts.php:61\n"
				},
				"test_paged_should_not_be_overridden_by_default_offset": {
					"name": "test_paged_should_not_be_overridden_by_default_offset",
					"failure": "Tests_Post_GetPosts::test_paged_should_not_be_overridden_by_default_offset\nFailed asserting that Array &0 (\n    0 => 698\n) is identical to Array &0 (\n    0 => 701\n).\n\n\/home\/public\/test\/tests\/phpunit\/tests\/post\/getPosts.php:83\n"
				},
				"test_explicit_offset_non_0_should_override_paged": {
					"name": "test_explicit_offset_non_0_should_override_paged",
					"failure": "Tests_Post_GetPosts::test_explicit_offset_non_0_should_override_paged\nFailed asserting that Array &0 (\n    0 => 700\n) is identical to Array &0 (\n    0 => 706\n).\n\n\/home\/public\/test\/tests\/phpunit\/tests\/post\/getPosts.php:126\n"
				}
			}
		},
		"Tests_Query_CommentCount": {
			"name": "Tests_Query_CommentCount",
			"tests": "15",
			"failures": "0",
			"errors": "0",
			"testcases": []
		},
		"Tests_Query_Conditionals": {
			"name": "Tests_Query_Conditionals",
			"tests": "83",
			"failures": "6",
			"errors": "4",
			"testcases": {
				"test_home": {
					"name": "test_home",
					"failure": "Tests_Query_Conditionals::test_home\nis_404 is true but is expected to be false. \nis_front_page is false but is expected to be true. \nis_home is false but is expected to be true.\n\n\/home\/public\/test\/tests\/phpunit\/includes\/testcase.php:754\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:32\n"
				},
				"test_page_page_2": {
					"name": "test_page_page_2",
					"failure": "Tests_Query_Conditionals::test_page_page_2\nFailed asserting that 750 matches expected 769.\n\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:207\n"
				},
				"test_page_page_2_no_slash": {
					"name": "test_page_page_2_no_slash",
					"failure": "Tests_Query_Conditionals::test_page_page_2_no_slash\nFailed asserting that 750 matches expected 770.\n\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:220\n"
				},
				"test_pagination_of_posts_page": {
					"name": "test_pagination_of_posts_page",
					"failure": "Tests_Query_Conditionals::test_pagination_of_posts_page\nis_home is false but is expected to be true. \nis_page is true but is expected to be false. \nis_posts_page is false but is expected to be true. \nis_singular is true but is expected to be false.\n\n\/home\/public\/test\/tests\/phpunit\/includes\/testcase.php:754\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:231\n"
				},
				"test_paged": {
					"name": "test_paged",
					"failure": "Tests_Query_Conditionals::test_paged\nis_front_page is false but is expected to be true.\n\n\/home\/public\/test\/tests\/phpunit\/includes\/testcase.php:754\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:282\n"
				},
				"test_tag": {
					"name": "test_tag",
					"failure": "Tests_Query_Conditionals::test_tag\nFailed asserting that false is true.\n\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:425\n"
				},
				"test_author_paged": {
					"name": "test_author_paged",
					"error": "Tests_Query_Conditionals::test_author_paged\nmysqli_real_escape_string() expects parameter 2 to be string, object given\n\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1108\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1190\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1245\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1922\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1844\n\/home\/public\/test\/src\/wp-includes\/post.php:3317\n\/home\/public\/test\/tests\/phpunit\/includes\/factory\/class-wp-unittest-factory-for-post.php:27\n\/home\/public\/test\/tests\/phpunit\/includes\/factory\/class-wp-unittest-factory-for-thing.php:32\n\/home\/public\/test\/tests\/phpunit\/includes\/factory\/class-wp-unittest-factory-for-thing.php:55\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:457\n"
				},
				"test_author": {
					"name": "test_author",
					"error": "Tests_Query_Conditionals::test_author\nmysqli_real_escape_string() expects parameter 2 to be string, object given\n\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1108\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1190\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1245\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1922\n\/home\/public\/test\/src\/wp-includes\/wp-db.php:1844\n\/home\/public\/test\/src\/wp-includes\/post.php:3317\n\/home\/public\/test\/tests\/phpunit\/includes\/factory\/class-wp-unittest-factory-for-post.php:27\n\/home\/public\/test\/tests\/phpunit\/includes\/factory\/class-wp-unittest-factory-for-thing.php:32\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:465\n"
				},
				"test_is_category_should_not_match_numeric_id_to_slug_beginning_with_id": {
					"name": "test_is_category_should_not_match_numeric_id_to_slug_beginning_with_id",
					"error": "Tests_Query_Conditionals::test_is_category_should_not_match_numeric_id_to_slug_beginning_with_id\nObject of class WP_Error could not be converted to string\n\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:1215\n"
				},
				"test_is_tag_should_not_match_numeric_id_to_slug_beginning_with_id": {
					"name": "test_is_tag_should_not_match_numeric_id_to_slug_beginning_with_id",
					"error": "Tests_Query_Conditionals::test_is_tag_should_not_match_numeric_id_to_slug_beginning_with_id\nObject of class WP_Error could not be converted to string\n\n\/home\/public\/test\/tests\/phpunit\/tests\/query\/conditionals.php:1257\n"
				}
			}
		}
	}
}
```