### PR TITLE
Only use SSH connection details when non-empty

### DIFF
--- a/cleanup.php
+++ b/cleanup.php
@@ -24,7 +24,7 @@ perform_operations( array(
 ) );
 
 // Clean up the test directory in remote environments
-if ( false !== $WPT_SSH_CONNECT ) {
+if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	perform_operations( array(
 		'ssh ' . $WPT_SSH_OPTIONS . ' ' . escapeshellarg( $WPT_SSH_CONNECT ) . ' ' . escapeshellarg( $WPT_RM_TEST_DIR_CMD ),
 	) );

--- a/functions.php
+++ b/functions.php
@@ -23,7 +23,7 @@ function check_required_env() {
 		}
 	}
 
-	if ( false === getenv( 'WPT_SSH_CONNECT' )
+	if ( empty( getenv( 'WPT_SSH_CONNECT' ) )
 		&& getenv( 'WPT_TEST_DIR' ) !== getenv( 'WPT_PREPARE_DIR' ) ) {
 		error_message( 'WPT_TEST_DIR must be the same as WPT_PREPARE_DIR when running locally.' );
 	}

--- a/prepare.php
+++ b/prepare.php
@@ -17,7 +17,7 @@ $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 
 // Set the ssh private key if it's set
 $WPT_SSH_PRIVATE_KEY_BASE64 = getenv( 'WPT_SSH_PRIVATE_KEY_BASE64' );
-if ( false !== $WPT_SSH_PRIVATE_KEY_BASE64 ) {
+if ( ! empty( $WPT_SSH_PRIVATE_KEY_BASE64 ) ) {
 	log_message( 'Securely extracting WPT_SSH_PRIVATE_KEY_BASE64 into ~/.ssh/id_rsa' );
 	file_put_contents( getenv( 'HOME' ) . '/.ssh/id_rsa', base64_decode( $WPT_SSH_PRIVATE_KEY_BASE64 ) );
 	perform_operations( array(
@@ -95,7 +95,7 @@ $contents = str_replace( array_keys( $search_replace ), array_values( $search_re
 file_put_contents( $WPT_PREPARE_DIR . '/wp-tests-config.php', $contents );
 
 // Deliver all files to test environment
-if ( false !== $WPT_SSH_CONNECT ) {
+if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	perform_operations( array(
 		'rsync -rv --exclude=".git/" -e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( trailingslashit( $WPT_PREPARE_DIR )  ) . ' ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $WPT_TEST_DIR ),
 	) );

--- a/report.php
+++ b/report.php
@@ -24,7 +24,7 @@ $message = trim( exec('git -C ' . escapeshellarg( $WPT_PREPARE_DIR ) . ' log -1 
 log_message('Copying junit.xml results');
 $junit_location = escapeshellarg( $WPT_TEST_DIR ) . '/tests/phpunit/build/logs/*';
 
-if ( false !== $WPT_SSH_CONNECT ) {
+if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	$junit_location = '-e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $junit_location );
 }
 

--- a/test.php
+++ b/test.php
@@ -16,7 +16,7 @@ $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
 $WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . '; ' . $WPT_PHP_EXECUTABLE . ' phpunit.phar';
 
 // Run phpunit in the test environment
-if ( false !== $WPT_SSH_CONNECT ) {
+if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	$WPT_PHPUNIT_CMD = 'ssh ' . $WPT_SSH_OPTIONS . ' ' . escapeshellarg( $WPT_SSH_CONNECT ) . ' ' . escapeshellarg( $WPT_PHPUNIT_CMD );
 }
 perform_operations( array(


### PR DESCRIPTION
If they're set but empty, we can assume the user forgot to comment them
out