### PR TITLE
Update prepare.php to use the specified PHP executable for testing

### DIFF
--- a/prepare.php
+++ b/prepare.php
@@ -14,6 +14,7 @@ $WPT_PREPARE_DIR = getenv( 'WPT_PREPARE_DIR' );
 $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
+$WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE') ? : 'php';
 
 // Set the ssh private key if it's set
 $WPT_SSH_PRIVATE_KEY_BASE64 = getenv( 'WPT_SSH_PRIVATE_KEY_BASE64' );
@@ -88,13 +89,15 @@ if ( 'cli' === php_sapi_name() && defined( 'WP_INSTALLING' ) && WP_INSTALLING ) 
 EOT;
 $logger_replace_string = '// wordpress/wp-config.php will be ignored.' . PHP_EOL;
 $system_logger = $logger_replace_string . $system_logger;
+$php_binary_string = 'define( \'WP_PHP_BINARY\', \''. $WPT_PHP_EXECUTABLE . '\' );';
 $search_replace = array(
-	'wptests_'                => getenv( 'WPT_TABLE_PREFIX' ) ? : 'wptests_',
-	'youremptytestdbnamehere' => getenv( 'WPT_DB_NAME' ),
-	'yourusernamehere'        => getenv( 'WPT_DB_USER' ),
-	'yourpasswordhere'        => getenv( 'WPT_DB_PASSWORD' ),
-	'localhost'               => getenv( 'WPT_DB_HOST' ),
-	$logger_replace_string    => $system_logger,
+	'wptests_'                              => getenv( 'WPT_TABLE_PREFIX' ) ? : 'wptests_',
+	'youremptytestdbnamehere'               => getenv( 'WPT_DB_NAME' ),
+	'yourusernamehere'                      => getenv( 'WPT_DB_USER' ),
+	'yourpasswordhere'                      => getenv( 'WPT_DB_PASSWORD' ),
+	'localhost'                             => getenv( 'WPT_DB_HOST' ),
+	'define( \'WP_PHP_BINARY\', \'php\' );' => $php_binary_string,
+	$logger_replace_string                  => $system_logger,
 );
 $contents = str_replace( array_keys( $search_replace ), array_values( $search_replace ), $contents );
 file_put_contents( $WPT_PREPARE_DIR . '/wp-tests-config.php', $contents );


### PR DESCRIPTION
This PR uses the PHP executable specified in the `WPT_PHP_EXECUTABLE` to run the unit tests. This then allows the tests to be run on systems where multiple PHP versions have been installed but may not necessarily be the system default.