### PR TITLE
Fix Environment Information Reporting

### DIFF
--- a/prepare.php
+++ b/prepare.php
@@ -88,7 +88,7 @@ if ( 'cli' === php_sapi_name() && defined( 'WP_INSTALLING' ) && WP_INSTALLING ) 
 	echo PHP_EOL;
 }
 EOT;
-$logger_replace_string = '// wordpress/wp-config.php will be ignored.' . PHP_EOL;
+$logger_replace_string = '// ** MySQL settings ** //' . PHP_EOL;
 $system_logger = $logger_replace_string . $system_logger;
 $php_binary_string = 'define( \'WP_PHP_BINARY\', \''. $WPT_PHP_EXECUTABLE . '\' );';
 $search_replace = array(


### PR DESCRIPTION
Changes the string that is replaced in `wp-tests-config.php` to account
for https://core.trac.wordpress.org/changeset/47122.

See: WordPress/phpunit-test-runner#105