### PR TITLE
remove verbose mode for rsync

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -57,5 +57,5 @@ export WPT_SSH_OPTIONS=
 export WPT_SSH_PRIVATE_KEY_BASE64=
 
 # Output logging
-# Defaults to 'normal', use 'verbose' to increase verbosity
-export WPT_LOGGING=
+# Defaults to '', use 'verbose' to increase verbosity
+export WPT_DEBUG=

--- a/.env.default
+++ b/.env.default
@@ -55,3 +55,7 @@ export WPT_SSH_OPTIONS=
 
 # SSH private key, base64 encoded.
 export WPT_SSH_PRIVATE_KEY_BASE64=
+
+# Output logging
+# Defaults to 'normal', use 'verbose' to increase verbosity
+export WPT_LOGGING=

--- a/.env.default
+++ b/.env.default
@@ -57,5 +57,5 @@ export WPT_SSH_OPTIONS=
 export WPT_SSH_PRIVATE_KEY_BASE64=
 
 # Output logging
-# Defaults to '', use 'verbose' to increase verbosity
+# Use 'verbose' to increase verbosity
 export WPT_DEBUG=

--- a/prepare.php
+++ b/prepare.php
@@ -15,7 +15,7 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
-$WPT_DEBUG = getenv( 'WPT_DEBUG' ) ? : '';
+$WPT_DEBUG = getenv( 'WPT_DEBUG' );
 
 // Set the ssh private key if it's set.
 $WPT_SSH_PRIVATE_KEY_BASE64 = getenv( 'WPT_SSH_PRIVATE_KEY_BASE64' );

--- a/prepare.php
+++ b/prepare.php
@@ -15,7 +15,7 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE') ? : 'php';
-$WPT_LOGGING = getenv( 'WPT_LOGGING') ? : 'normal';
+$WPT_DEBUG = getenv( 'WPT_DEBUG') ? : '';
 
 // Set the ssh private key if it's set.
 $WPT_SSH_PRIVATE_KEY_BASE64 = getenv( 'WPT_SSH_PRIVATE_KEY_BASE64' );
@@ -108,7 +108,7 @@ file_put_contents( $WPT_PREPARE_DIR . '/wp-tests-config.php', $contents );
 if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	$rsync_options = '-r';
 
-	if ( 'verbose' === $WPT_LOGGING ) {
+	if ( 'verbose' === $WPT_DEBUG ) {
 		$rsync_options = $rsync_options . 'v';
 	}
 

--- a/prepare.php
+++ b/prepare.php
@@ -106,7 +106,7 @@ file_put_contents( $WPT_PREPARE_DIR . '/wp-tests-config.php', $contents );
 // Deliver all files to test environment.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	perform_operations( array(
-		'rsync -rv --exclude=".git/" -e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( trailingslashit( $WPT_PREPARE_DIR )  ) . ' ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $WPT_TEST_DIR ),
+		'rsync -r --exclude=".git/" -e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( trailingslashit( $WPT_PREPARE_DIR )  ) . ' ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $WPT_TEST_DIR ),
 	) );
 }
 

--- a/prepare.php
+++ b/prepare.php
@@ -15,6 +15,7 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE') ? : 'php';
+$WPT_LOGGING = getenv( 'WPT_LOGGING') ? : 'normal';
 
 // Set the ssh private key if it's set.
 $WPT_SSH_PRIVATE_KEY_BASE64 = getenv( 'WPT_SSH_PRIVATE_KEY_BASE64' );
@@ -105,8 +106,14 @@ file_put_contents( $WPT_PREPARE_DIR . '/wp-tests-config.php', $contents );
 
 // Deliver all files to test environment.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {
+	$rsync_options = '-r';
+
+	if ( 'verbose' === $WPT_LOGGING ) {
+		$rsync_options = $rsync_options . 'v';
+	}
+
 	perform_operations( array(
-		'rsync -r --exclude=".git/" -e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( trailingslashit( $WPT_PREPARE_DIR )  ) . ' ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $WPT_TEST_DIR ),
+		'rsync ' . $rsync_options . ' --exclude=".git/" -e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( trailingslashit( $WPT_PREPARE_DIR )  ) . ' ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $WPT_TEST_DIR ),
 	) );
 }
 

--- a/prepare.php
+++ b/prepare.php
@@ -14,8 +14,8 @@ $WPT_PREPARE_DIR = getenv( 'WPT_PREPARE_DIR' );
 $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
-$WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE') ? : 'php';
-$WPT_DEBUG = getenv( 'WPT_DEBUG') ? : '';
+$WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
+$WPT_DEBUG = getenv( 'WPT_DEBUG' ) ? : '';
 
 // Set the ssh private key if it's set.
 $WPT_SSH_PRIVATE_KEY_BASE64 = getenv( 'WPT_SSH_PRIVATE_KEY_BASE64' );

--- a/report.php
+++ b/report.php
@@ -14,6 +14,7 @@ $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_PREPARE_DIR = getenv( 'WPT_PREPARE_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' );
 $WPT_REPORT_API_KEY = getenv( 'WPT_REPORT_API_KEY' );
+$WPT_LOGGING = getenv( 'WPT_LOGGING') ? : 'normal';
 
 log_message('Getting SVN Revision');
 $rev = exec('git --git-dir=' . escapeshellarg( $WPT_PREPARE_DIR ) . '/.git log -1 --pretty=%B | grep "git-svn-id:" | cut -d " " -f 2 | cut -d "@" -f 2');
@@ -28,7 +29,13 @@ if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	$junit_location = '-e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $junit_location );
 }
 
-$junit_exec = 'rsync -rv ' . $junit_location . ' ' . escapeshellarg( $WPT_PREPARE_DIR );
+$rsync_options = '-r';
+
+if ( 'verbose' === $WPT_LOGGING ) {
+	$rsync_options = $rsync_options . 'v';
+}
+
+$junit_exec = 'rsync ' . $rsync_options . ' ' . $junit_location . ' ' . escapeshellarg( $WPT_PREPARE_DIR );
 perform_operations( array(
 	$junit_exec,
 ) );

--- a/report.php
+++ b/report.php
@@ -14,7 +14,7 @@ $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_PREPARE_DIR = getenv( 'WPT_PREPARE_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' );
 $WPT_REPORT_API_KEY = getenv( 'WPT_REPORT_API_KEY' );
-$WPT_DEBUG = getenv( 'WPT_DEBUG' ) ? : '';
+$WPT_DEBUG = getenv( 'WPT_DEBUG' );
 
 log_message('Getting SVN Revision');
 $rev = exec('git --git-dir=' . escapeshellarg( $WPT_PREPARE_DIR ) . '/.git log -1 --pretty=%B | grep "git-svn-id:" | cut -d " " -f 2 | cut -d "@" -f 2');

--- a/report.php
+++ b/report.php
@@ -14,7 +14,7 @@ $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_PREPARE_DIR = getenv( 'WPT_PREPARE_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' );
 $WPT_REPORT_API_KEY = getenv( 'WPT_REPORT_API_KEY' );
-$WPT_LOGGING = getenv( 'WPT_LOGGING') ? : 'normal';
+$WPT_DEBUG = getenv( 'WPT_DEBUG' ) ? : '';
 
 log_message('Getting SVN Revision');
 $rev = exec('git --git-dir=' . escapeshellarg( $WPT_PREPARE_DIR ) . '/.git log -1 --pretty=%B | grep "git-svn-id:" | cut -d " " -f 2 | cut -d "@" -f 2');
@@ -31,7 +31,7 @@ if ( ! empty( $WPT_SSH_CONNECT ) ) {
 
 $rsync_options = '-r';
 
-if ( 'verbose' === $WPT_LOGGING ) {
+if ( 'verbose' === $WPT_DEBUG ) {
 	$rsync_options = $rsync_options . 'v';
 }
 


### PR DESCRIPTION
I had problems with travis and the verbose mode of `rsync`:

> The job exceeded the maximum log length, and has been terminated.

I would suggest to remove the flag, or at least to hide it behind an `env` var.