### PR TITLE
Install and use PHPUnit via composer.

### DIFF
--- a/prepare.php
+++ b/prepare.php
@@ -113,7 +113,7 @@ if ( ! empty( $WPT_SSH_CONNECT ) ) {
 	$php_version_cmd = 'ssh ' . $WPT_SSH_OPTIONS . ' ' . escapeshellarg( $WPT_SSH_CONNECT ) . ' ' . escapeshellarg( $php_version_cmd );
 }
 $env_php_version = exec( $php_version_cmd, $output, $retval );
-log_message("Environment PHP Version: $env_php_version");
+log_message( "Environment PHP Version: $env_php_version" );
 
 // Set Composer PHP environment, then run Composer.
 if ( $retval === 0 ) {

--- a/prepare.php
+++ b/prepare.php
@@ -122,6 +122,10 @@ if ( substr( $env_php_version, 0 , 2 ) === '8.' ) {
 	$env_php_version = '7.4';
 }
 
+if ( version_compare( $env_php_version, '5.6', '<' ) ) {
+	error_message( "The test runner is not compatible with PHP < 5.6." );
+}
+
 // If PHP version is 5.6-7.0, download PHPUnit 5.7 phar directly.
 if ( version_compare( $env_php_version, '7.1', '<' ) ) {
 	perform_operations( array(

--- a/test.php
+++ b/test.php
@@ -15,7 +15,7 @@ $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no'
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
 
 // This uses `||` to run PHPUnit when it is downloaded manually (like for PHP 5.6-7.0) rather than through Composer.
-$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ./vendor/phpunit/phpunit/phpunit || php phpunit.phar';
+$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ' . $WPT_PHP_EXECUTABLE . ' ./vendor/phpunit/phpunit/phpunit || ' . $WPT_PHP_EXECUTABLE . ' phpunit.phar';
 
 // Run phpunit in the test environment.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {

--- a/test.php
+++ b/test.php
@@ -13,6 +13,8 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
+
+// This uses `||` to run PHPUnit when it is downloaded manually (like for PHP 5.6-7.0) rather than through Composer.
 $WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ./vendor/phpunit/phpunit/phpunit || php phpunit.phar';
 
 // Run phpunit in the test environment.

--- a/test.php
+++ b/test.php
@@ -13,7 +13,7 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
-$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ./vendor/phpunit/phpunit/phpunit';
+$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ./vendor/phpunit/phpunit/phpunit || php phpunit.phar';
 
 // Run phpunit in the test environment.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {

--- a/test.php
+++ b/test.php
@@ -13,7 +13,7 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
-$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . '; ' . $WPT_PHP_EXECUTABLE . ' vendor/phpunit/phpunit/phpunit';
+$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ./vendor/phpunit/phpunit/phpunit';
 
 // Run phpunit in the test environment.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {

--- a/test.php
+++ b/test.php
@@ -13,7 +13,7 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
-$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . '; ' . $WPT_PHP_EXECUTABLE . ' phpunit.phar';
+$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . '; ' . $WPT_PHP_EXECUTABLE . ' vendor/phpunit/phpunit/phpunit';
 
 // Run phpunit in the test environment.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {


### PR DESCRIPTION
The changes include:
- Downloads Composer PHAR to prepare directory when it is not available
- Checks test environment PHP version, and runs Composer to download PHPUnit on prepare environment with PHP < 7.1.
- Uses installed PHPUnit from Composer on test environment for PHP 7.1+

~This is a rough first pass. Putting here so folks can use it as a starting point.~
~I'm getting a segfault during tests on my installed version of PHP8, but it might be because it's PHP 8 RC1, and I need to update it.~ (Fixed)
~TODO: Install/download Composer so that it isn't necessary to be installed globally on the prepare environment.~ (Done)

See: #121