### PR TITLE
Use local Grunt, rather than relying on global.

### DIFF
--- a/prepare.php
+++ b/prepare.php
@@ -35,7 +35,7 @@ perform_operations( array(
 	'wget -O ' .  escapeshellarg( $WPT_PREPARE_DIR . '/phpunit.phar' ) . ' https://phar.phpunit.de/phpunit-5.7.phar',
 	'wget -O ' . escapeshellarg( $WPT_PREPARE_DIR . '/tests/phpunit/data/plugins/wordpress-importer.zip' ) . ' https://downloads.wordpress.org/plugin/wordpress-importer.zip',
 	'cd ' . escapeshellarg( $WPT_PREPARE_DIR . '/tests/phpunit/data/plugins/' ) . '; unzip wordpress-importer.zip; rm wordpress-importer.zip',
-	'cd ' . escapeshellarg( $WPT_PREPARE_DIR ) . '; npm install && grunt build',
+	'cd ' . escapeshellarg( $WPT_PREPARE_DIR ) . '; npm install && npm run build',
 ) );
 
 // Replace variables in the wp-config.php file.


### PR DESCRIPTION
I ran into issues with the test runner building on a system where global Grunt was not available.

This seems to work around the issue, and uses the locally installed Grunt after `npm install`.

Are there any drawbacks to doing it this way?