### PR TITLE
Remove shell exec convert

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -214,9 +214,6 @@ function get_env_details() {
 	$curl = array_shift( $curl_bits );
 	$env['system_utils']['curl'] = trim( $curl );
 	$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
-	$ret = shell_exec( 'convert --version' );
-	preg_match( '#Version: ImageMagick ([^\s]+)#', $ret, $matches );
-	$env['system_utils']['imagemagick'] = isset( $matches[1] ) ? $matches[1] : false;
 	$env['system_utils']['openssl'] = str_replace( 'OpenSSL ', '', trim( shell_exec( 'openssl version' ) ) );
 	return $env;
 }

--- a/functions.php
+++ b/functions.php
@@ -202,6 +202,7 @@ function get_env_details() {
 		'mod_xml',
 		'mysqli',
 		'imagick',
+		'gmagick',
 		'pcre',
 		'xml',
 		'xmlreader',
@@ -214,6 +215,17 @@ function get_env_details() {
 	$curl = array_shift( $curl_bits );
 	$env['system_utils']['curl'] = trim( $curl );
 	$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
+	if ( class_exists( 'Imagick' ) ) {
+		$imagick = new Imagick();
+		$version = $imagick->getVersion();
+		preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', $version['versionString'], $version );
+		$env['system_utils']['imagemagick'] = $version[1];
+	} elseif ( class_exists( 'Gmagick' ) ) {
+		$gmagick = new Gmagick();
+		$version = $gmagick->getversion();
+		preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', $version['versionString'], $version );
+		$env['system_utils']['graphicsmagick'] = $version[1];
+	}
 	$env['system_utils']['openssl'] = str_replace( 'OpenSSL ', '', trim( shell_exec( 'openssl version' ) ) );
 	return $env;
 }

--- a/prepare.php
+++ b/prepare.php
@@ -66,6 +66,7 @@ if ( ! is_dir(  __DIR__ . '/tests/phpunit/build/logs/' ) ) {
 	'mod_xml',
 	'mysqli',
 	'imagick',
+	'gmagick',
 	'pcre',
 	'xml',
 	'xmlreader',
@@ -78,6 +79,17 @@ foreach( \$php_modules as \$php_module ) {
 \$curl = array_shift( \$curl_bits );
 \$env['system_utils']['curl'] = trim( \$curl );
 \$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
+if ( class_exists( 'Imagick' ) ) {
+	\$imagick = new Imagick();
+	\$version = \$imagick->getVersion();
+	preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', \$version['versionString'], \$version );
+	\$env['system_utils']['imagemagick'] = \$version[1];
+} elseif ( class_exists( 'Gmagick' ) ) {
+	\$gmagick = new Gmagick();
+	\$version = \$gmagick->getversion();
+	preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', \$version['versionString'], \$version );
+	\$env['system_utils']['graphicsmagick'] = \$version[1];
+}
 \$env['system_utils']['openssl'] = str_replace( 'OpenSSL ', '', trim( shell_exec( 'openssl version' ) ) );
 file_put_contents( __DIR__ . '/tests/phpunit/build/logs/env.json', json_encode( \$env, JSON_PRETTY_PRINT ) );
 if ( 'cli' === php_sapi_name() && defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {

--- a/prepare.php
+++ b/prepare.php
@@ -78,9 +78,6 @@ foreach( \$php_modules as \$php_module ) {
 \$curl = array_shift( \$curl_bits );
 \$env['system_utils']['curl'] = trim( \$curl );
 \$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
-\$ret = shell_exec( 'convert --version' );
-preg_match( '#Version: ImageMagick ([^\s]+)#', \$ret, \$matches );
-\$env['system_utils']['imagemagick'] = isset( \$matches[1] ) ? \$matches[1] : false;
 \$env['system_utils']['openssl'] = str_replace( 'OpenSSL ', '', trim( shell_exec( 'openssl version' ) ) );
 file_put_contents( __DIR__ . '/tests/phpunit/build/logs/env.json', json_encode( \$env, JSON_PRETTY_PRINT ) );
 if ( 'cli' === php_sapi_name() && defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {


### PR DESCRIPTION
Fixes #65

This removes the `imagemagick` reporting under `system_utils` as the Package information isn't actually needed.

`imagick` php_module is already reported earlier in the same array. `convert` isn't always present on systems since the imagemagick package might not be installed along the php_module.