### PR TITLE
Skip action for this repo: use `${{ false }}` instead of `never()`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Remove this line if Github Actions is your preferred means of running the tests.
-    if: never()
+    if: ${{ false }}
 
     env:
       # This is only a subset/example of env vars available. See the `.env.default` file for a full list.


### PR DESCRIPTION
@desrosj `never()` seems to cause a lot if issues, so I changed it to `${{ false }}`.

See: https://github.com/WordPress/phpunit-test-runner/actions