### PR TITLE
cleanup tests even if reporting fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Report the results
         run: php report.php
+        # Prevent the workflow from stopping if the reporting fails.
+        continue-on-error: true
 
       - name: Cleanup
         run: php cleanup.php


### PR DESCRIPTION
If the reporting fails, the webspace will not be cleaned and that might cause side effects on the next run.