### PR TITLE
Add `--dont-report-useless-tests` flag by default.

### DIFF
--- a/test.php
+++ b/test.php
@@ -15,7 +15,7 @@ $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no'
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
 
 // This uses `||` to run PHPUnit when it is downloaded manually (like for PHP 5.6-7.0) rather than through Composer.
-$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ' . $WPT_PHP_EXECUTABLE . ' ./vendor/phpunit/phpunit/phpunit || ' . $WPT_PHP_EXECUTABLE . ' phpunit.phar';
+$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ' . $WPT_PHP_EXECUTABLE . ' ./vendor/phpunit/phpunit/phpunit --dont-report-useless-tests || ' . $WPT_PHP_EXECUTABLE . ' phpunit.phar --dont-report-useless-tests';
 
 // Run phpunit in the test environment.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {


### PR DESCRIPTION
Risky tests cause "Failed" statuses on the "Hosting Tests results" page.
As these don't provide insight into the functionality of WordPress,
they should not be reported by default.

If the reporting of risky tests is desired, a `WPT_PHPUNIT_CMD` value can
be set in `.env`.

Resolves #167.