### PR TITLE
Update Travis CI to Use Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 node_js:
-  - node
+  - 14
 
 before_install:
   - npm install -g npm@latest

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prep environment:
 
 * PHP 5.6 or greater (to run scripts).
 * Utilities: `git` version 1.8.5 or greater, `rsync`, `wget`, `unzip`.
-* Node.js including `npm` and `grunt` packages
+* Node.js 14.x, including `npm` and `grunt` packages
 
 Test environment:
 


### PR DESCRIPTION
This PR is a follow-up to #174, specifically to [this comment](https://github.com/WordPress/phpunit-test-runner/issues/174#issuecomment-1181607336), requesting that the test runner use Node 14 on its own.

## What Has Changed?
1. In `.travis.yml` the `node_js` setting specifies `node`, [which is the latest stable release](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions). However, the project's `package.json` is configured for Node 14, and to avoid compile errors under other versions, this has been changed to specifically use version `14`.
2. Following a Hosting Handbook [tests documentation update related to this requirement](https://github.com/WordPress/hosting-handbook/commit/91663bfd3672b9721bc40402bdefd4bb50c900f7), the README file now also indicates the need for Node 14.

## Other Considerations
It is also possible to use a `.nvmrc` file to enforce use of a specific Node version, but [per the Travis documentation](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions-using-nvmrc) this file would only be checked if the `node_js` key wasn't set (but in this case, it _is_ set to `node`). Thus updating `.travis.yml` directly seemed most straightforward.

## Testing
I would appreciate some help from a community member who already has a Travis setup to validate this update. It may require resetting or changing the default Node version back to latest, and _then_ re-installing/re-running this project.