### PR TITLE
Use curl information from library rather than curl --version

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -211,9 +211,9 @@ function get_env_details() {
 	foreach( $php_modules as $php_module ) {
 		$env['php_modules'][ $php_module ] = phpversion( $php_module );
 	}
-	$curl_bits = explode( PHP_EOL, str_replace( 'curl ', '', shell_exec( 'curl --version' ) ) );
-	$curl = array_shift( $curl_bits );
-	$env['system_utils']['curl'] = trim( $curl );
+	function curl_selected_bits($k) { return in_array($k, array('version', 'ssl_version', 'libz_version')); }
+	$curl_bits = curl_version();
+	$env['system_utils']['curl'] = implode(' ',array_values(array_filter($curl_bits, 'curl_selected_bits',ARRAY_FILTER_USE_KEY) ));
 	$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
 	if ( class_exists( 'Imagick' ) ) {
 		$imagick = new Imagick();

--- a/prepare.php
+++ b/prepare.php
@@ -77,9 +77,9 @@ if ( ! is_dir(  __DIR__ . '/tests/phpunit/build/logs/' ) ) {
 foreach( \$php_modules as \$php_module ) {
 	\$env['php_modules'][ \$php_module ] = phpversion( \$php_module );
 }
-\$curl_bits = explode( PHP_EOL, str_replace( 'curl ', '', shell_exec( 'curl --version' ) ) );
-\$curl = array_shift( \$curl_bits );
-\$env['system_utils']['curl'] = trim( \$curl );
+function curl_selected_bits(\$k) { return in_array(\$k, array('version', 'ssl_version', 'libz_version')); }
+\$curl_bits = curl_version();
+\$env['system_utils']['curl'] = implode(' ',array_values(array_filter(\$curl_bits, 'curl_selected_bits',ARRAY_FILTER_USE_KEY) ));
 \$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
 if ( class_exists( 'Imagick' ) ) {
 	\$imagick = new Imagick();


### PR DESCRIPTION
There is a chance the curl executable could be of different version than the libcurl used by php.

Include the curl library version, the openssl version and zlib version.

This is less than curl --version of the form:

curl 7.82.0 (x86_64-redhat-linux-gnu) libcurl/7.82.0 OpenSSL/3.0.5 zlib/1.2.11 brotli/1.0.9 libidn2/2.3.3 libpsl/0.21.1 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.46.0 OpenLDAP/2.6.2

Apologies as my php programming isn't the strongest.