### PR TITLE
remove gs --version

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -214,7 +214,6 @@ function get_env_details() {
 	$curl_bits = explode( PHP_EOL, str_replace( 'curl ', '', shell_exec( 'curl --version' ) ) );
 	$curl = array_shift( $curl_bits );
 	$env['system_utils']['curl'] = trim( $curl );
-	$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
 	if ( class_exists( 'Imagick' ) ) {
 		$imagick = new Imagick();
 		$version = $imagick->getVersion();

--- a/prepare.php
+++ b/prepare.php
@@ -80,7 +80,6 @@ foreach( \$php_modules as \$php_module ) {
 \$curl_bits = explode( PHP_EOL, str_replace( 'curl ', '', shell_exec( 'curl --version' ) ) );
 \$curl = array_shift( \$curl_bits );
 \$env['system_utils']['curl'] = trim( \$curl );
-\$env['system_utils']['ghostscript'] = trim( shell_exec( 'gs --version' ) );
 if ( class_exists( 'Imagick' ) ) {
 	\$imagick = new Imagick();
 	\$version = \$imagick->getVersion();


### PR DESCRIPTION
The test suite doesn't appear to use gs, so remove it from the metadata.

Apologies for 3 merge conflicting prs but it was the logical separation of changes.