### PR TITLE
Add SQLite to the report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .env*
 vendor/
+package-lock.json

--- a/prepare.php
+++ b/prepare.php
@@ -77,6 +77,8 @@ if ( ! is_dir(  __DIR__ . '/tests/phpunit/build/logs/' ) ) {
 	'mod_xml',
 	'mysqli',
 	'pcre',
+	'sqlite',
+	'sqlite3',
 	'xml',
 	'xmlreader',
 	'zlib',


### PR DESCRIPTION
We need to start checking if hosters have SQLite PHP extensions, so we can check if it's possible to run the SQLite Object Cache and WordPress SQLite Database.

With this information, Core-Performance Team should look at the best time to recommend this extension.