### PR TITLE
[TASK] Use WPT_PHP_EXECUTABLE for composer

### DIFF
--- a/prepare.php
+++ b/prepare.php
@@ -338,7 +338,7 @@ if ( $retval === 0 ) {
 	) );
 
 	// Update the command to use the downloaded Composer phar file.
-	$composer_cmd .= $WPT_PHP_EXECUTABLE.' composer.phar ';
+	$composer_cmd .= $WPT_PHP_EXECUTABLE . ' composer.phar ';
 }
 
 // Set the PHP version for Composer to ensure compatibility and update dependencies.

--- a/prepare.php
+++ b/prepare.php
@@ -338,7 +338,7 @@ if ( $retval === 0 ) {
 	) );
 
 	// Update the command to use the downloaded Composer phar file.
-	$composer_cmd .= 'php composer.phar ';
+	$composer_cmd .= $WPT_PHP_EXECUTABLE.' composer.phar ';
 }
 
 // Set the PHP version for Composer to ensure compatibility and update dependencies.


### PR DESCRIPTION
Without it uses the hardcode `php` call.

However, we have 
`$WPT_PHP_EXECUTABLE = trim( getenv( 'WPT_PHP_EXECUTABLE' ) ) ? : 'php';`
for a reason

In our case, without this patch all works but the reporting/uploading bit:

`cd '/home/REDACTED/tmp' && php composer.phar config platform.php '8.2.28'
   ______
  / ____/___  ____ ___  ____  ____  ________  _____
 / /   / __ \/ __ `__ \/ __ \/ __ \/ ___/ _ \/ ___/
/ /___/ /_/ / / / / / / /_/ / /_/ (__  )  __/ /
\____/\____/_/ /_/ /_/ .___/\____/____/\___/_/
                    /_/
Composer version 2.8.9 2025-05-13 14:01:37

Usage:
  command [options] [arguments]

Options:
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
  -n, --no-interaction           Do not ask any interactive question
      --profile                  Display timing and memory usage information
      --no-plugins               Whether to disable plugins.
      --no-scripts               Skips the execution of all scripts defined in composer.json file.
  -d, --working-dir=WORKING-DIR  If specified, use the given directory as working directory.
      --no-cache                 Prevent use of the cache
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  about                Shows a short information about Composer
  archive              Creates an archive of this composer package
  audit                Checks for security vulnerability advisories for installed packages
  browse               [home] Opens the package's repository URL or homepage in your browser
  bump                 Increases the lower limit of your composer.json requirements to the currently installed versions
  check-platform-reqs  Check that platform requirements are satisfied
  clear-cache          [clearcache|cc] Clears composer's internal package cache
  compat               Runs the compat script as defined in composer.json
  completion           Dump the shell completion script
  config               Sets config options
  create-project       Creates new project from a package into given directory
  depends              [why] Shows which packages cause the given package to be installed
  diagnose             Diagnoses the system to identify common errors
  dump-autoload        [dumpautoload] Dumps the autoloader
  exec                 Executes a vendored binary/script
  format               Runs the format script as defined in composer.json
  fund                 Discover how to help fund the maintenance of your dependencies
  global               Allows running commands in the global composer dir ($COMPOSER_HOME)
  help                 Display help for a command
  init                 Creates a basic composer.json file in current directory
  install              [i] Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json
  licenses             Shows information about licenses of dependencies
  lint                 Runs the lint script as defined in composer.json
  list                 List commands
  outdated             Shows a list of installed packages that have updates available, including their latest version
  prohibits            [why-not] Shows which packages prevent the given package from being installed
  reinstall            Uninstalls and reinstalls the given package names
  remove               [rm|uninstall] Removes a package from the require or require-dev
  require              [r] Adds required packages to your composer.json and installs them
  run-script           [run] Runs the scripts defined in composer.json
  search               Searches for packages
  self-update          [selfupdate] Updates composer.phar to the latest version
  show                 [info] Shows information about packages
  status               Shows a list of locally modified packages
  suggests             Shows package suggestions
  test                 Runs the test script as defined in composer.json
  update               [u|upgrade] Updates your dependencies to the latest version according to composer.json, and updates the composer.lock file
  validate             Validates a composer.json and composer.lock
 lint
  lint:errors          Runs the lint:errors script as defined in composer.json
X-Powered-By: PHP/8.2.28
Content-type: text/html; charset=UTF-8

Warning: Composer should be invoked via the CLI version of PHP, not the cgi-fcgi SAPI
cd '/home/REDACTED/tmp' && php composer.phar update
   ______
  / ____/___  ____ ___  ____  ____  ________  _____
 / /   / __ \/ __ `__ \/ __ \/ __ \/ ___/ _ \/ ___/
/ /___/ /_/ / / / / / / /_/ / /_/ (__  )  __/ /
\____/\____/_/ /_/ /_/ .___/\____/____/\___/_/
                    /_/
Composer version 2.8.9 2025-05-13 14:01:37

Usage:
  command [options] [arguments]

Options:
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
  -n, --no-interaction           Do not ask any interactive question
      --profile                  Display timing and memory usage information
      --no-plugins               Whether to disable plugins.
      --no-scripts               Skips the execution of all scripts defined in composer.json file.
  -d, --working-dir=WORKING-DIR  If specified, use the given directory as working directory.
      --no-cache                 Prevent use of the cache
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  about                Shows a short information about Composer
  archive              Creates an archive of this composer package
  audit                Checks for security vulnerability advisories for installed packages
  browse               [home] Opens the package's repository URL or homepage in your browser
  bump                 Increases the lower limit of your composer.json requirements to the currently installed versions
  check-platform-reqs  Check that platform requirements are satisfied
  clear-cache          [clearcache|cc] Clears composer's internal package cache
  compat               Runs the compat script as defined in composer.json
  completion           Dump the shell completion script
  config               Sets config options
  create-project       Creates new project from a package into given directory
  depends              [why] Shows which packages cause the given package to be installed
  diagnose             Diagnoses the system to identify common errors
  dump-autoload        [dumpautoload] Dumps the autoloader
  exec                 Executes a vendored binary/script
  format               Runs the format script as defined in composer.json
  fund                 Discover how to help fund the maintenance of your dependencies
  global               Allows running commands in the global composer dir ($COMPOSER_HOME)
  help                 Display help for a command
  init                 Creates a basic composer.json file in current directory
  install              [i] Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json
  licenses             Shows information about licenses of dependencies
  lint                 Runs the lint script as defined in composer.json
  list                 List commands
  outdated             Shows a list of installed packages that have updates available, including their latest version
  prohibits            [why-not] Shows which packages prevent the given package from being installed
  reinstall            Uninstalls and reinstalls the given package names
  remove               [rm|uninstall] Removes a package from the require or require-dev
  require              [r] Adds required packages to your composer.json and installs them
  run-script           [run] Runs the scripts defined in composer.json
  search               Searches for packages
  self-update          [selfupdate] Updates composer.phar to the latest version
  show                 [info] Shows information about packages
  status               Shows a list of locally modified packages
  suggests             Shows package suggestions
  test                 Runs the test script as defined in composer.json
  update               [u|upgrade] Updates your dependencies to the latest version according to composer.json, and updates the composer.lock file
  validate             Validates a composer.json and composer.lock
 lint
  lint:errors          Runs the lint:errors script as defined in composer.json
X-Powered-By: PHP/8.2.28
Content-type: text/html; charset=UTF-8

Warning: Composer should be invoked via the CLI version of PHP, not the cgi-fcgi SAPI
Success: Prepared environment.
Environment variables pass checks.
cd '/home/REDACTED/tmp' && /usr/local/bin/php -q ./vendor/phpunit/phpunit/phpunit --dont-report-useless-tests
Could not open input file: ./vendor/phpunit/phpunit/phpunit
Error: Failed to perform operation.
Environment variables pass checks.
Getting SVN Revision
Getting SVN message
Copying junit.xml results
rsync -r '/home/REDACTED/tmp'/tests/phpunit/build/logs/* '/home/REDACTED/tmp'
rsync: change_dir "/home/REDACTED/tmp/tests/phpunit/build/logs" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1187) [sender=3.1.3]
Error: Failed to perform operation.`