### PR TITLE
Increase the minimum required version of PHP and clarify other minimums

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To use the Runner, the following is required (testing WordPress 6.5):
 - Server / hosting (infrastructure) with the usual configuration you use
 - A database where you can test (tables will be created and destroyed several times)
 - PHP 7.2+
-- MySQL 5.5+ / MariaDB 10.0+
+- MySQL 5.5.5+ / MariaDB 10.0+
 - NodeJS 20.x / npm 10.x / grunt
 - PHP Composer
 - Git, RSync, WGet, UnZip

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To use the Runner, the following is required (testing WordPress 6.5):
 - Server / hosting (infrastructure) with the usual configuration you use
 - A database where you can test (tables will be created and destroyed several times)
 - PHP 7.2+
-- MySQL 5.5.5+ / MariaDB 10.0+
+- MySQL 5.5.5+ / MariaDB 5.5.5+
 - NodeJS 20.x / npm 10.x / grunt
 - PHP Composer
 - Git, RSync, WGet, UnZip

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To use the Runner, the following is required (testing WordPress 6.5):
 
 - Server / hosting (infrastructure) with the usual configuration you use
 - A database where you can test (tables will be created and destroyed several times)
-- PHP 7.0+ (view )
+- PHP 7.2+
 - MySQL 5.5+ / MariaDB 10.0+
 - NodeJS 20.x / npm 10.x / grunt
 - PHP Composer

--- a/prepare.php
+++ b/prepare.php
@@ -304,13 +304,13 @@ if ( $retval !== 0 ) {
 log_message( 'Environment PHP Version: ' . $env_php_version );
 
 /**
- * Checks if the detected PHP version is below 7.0.
- * The test runner requires PHP version 7.0 or above, and if the environment's PHP version
+ * Checks if the detected PHP version is below 7.2.
+ * The test runner requires PHP version 7.2 or above, and if the environment's PHP version
  * is lower, it logs an error message and could terminate the script.
  */
-if ( version_compare( $env_php_version, '7.0', '<' ) ) {
-	// Logs an error message indicating the test runner's incompatibility with PHP versions below 7.0.
-	error_message( 'The test runner is not compatible with PHP < 7.0.' );
+if ( version_compare( $env_php_version, '7.2', '<' ) ) {
+	// Logs an error message indicating the test runner's incompatibility with PHP versions below 7.2.
+	error_message( 'The test runner is not compatible with PHP < 7.2.' );
 }
 
 /**


### PR DESCRIPTION
This increases the minimum required version of PHP from `7.0` to `7.2`, which is what [WordPress Core has required since WordPress 6.6](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/#supported-version-chart).

The version of MySQL required has also been changed from `5.5+` to `5.5.5+` which also matches the current minimum required version.

Since WordPress Core does not currently differentiate between MariaDB and MySQL when checking that the minimum required version is met, technically MariaDB 5.5.5+ is also supported. I've updated the README to also reflect this, but I'm unsure if there were other reasons within the test runner itself as to why `10.0+` was used previously.