### PR TITLE
Change the default value of `WPT_FLAVOR`

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -68,7 +68,7 @@ export WPT_CERTIFICATE_VALIDATION=1
 # WordPress flavor
 # 0 = WordPress (simple version)
 # 1 = WordPress Multisite
-export WPT_FLAVOR=1
+export WPT_FLAVOR=0
 
 # Extra tests (groups)
 # 0 = none


### PR DESCRIPTION
This changes the default value for `WPT_FLAVOR` in the `.env.default` file from `1` (multisite) to `0` (single site).

While receiving test reports from environments running multisite offers additional confirmation, running the tests as a single site is the more appropriate default.

The code throughout the repository responsible for handling the `WPT_FLAVOR` environment variable currently uses single site as the fallback when the variable is not set.

This was spun off from #212.