### PR TITLE
Fix parse error caused by recent merges

### DIFF
--- a/test.php
+++ b/test.php
@@ -66,7 +66,7 @@ unset( $WPT_EXTRATESTS_INI );
  */
 $WPT_PHPUNIT_CMD = trim( getenv( 'WPT_PHPUNIT_CMD' ) );
 if ( empty( $WPT_PHPUNIT_CMD ) ) {
-	$WPT_PHPUNIT_CMD = escapeshellarg( 'cd ' . $runner_vars['WPT_TEST_DIR'] ) . ' && ' . $runner_vars['WPT_PHP_EXECUTABLE'] . ' ./vendor/phpunit/phpunit/phpunit --dont-report-useless-tests' . $WPT_FLAVOR_TXT . $WPT_EXTRATESTS_TXT );
+	$WPT_PHPUNIT_CMD = escapeshellarg( 'cd ' . $runner_vars['WPT_TEST_DIR'] . ' && ' . $runner_vars['WPT_PHP_EXECUTABLE'] . ' ./vendor/phpunit/phpunit/phpunit --dont-report-useless-tests' . $WPT_FLAVOR_TXT . $WPT_EXTRATESTS_TXT );
 } else {
 	$WPT_PHPUNIT_CMD = escapeshellarg( $WPT_PHPUNIT_CMD );
 }


### PR DESCRIPTION
Fixes #271.

This appears to be the result of a bad merge conflict resolution in #264 (specifically https://github.com/WordPress/phpunit-test-runner/pull/264/commits/7f5365d8aa2c3c6cf7dae2f9d1519ec3b0b86c93).