### PR TITLE
Expand the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ vendor/
 package-lock.json
 commit.json
 ignore.json
+
+# Exclude the default test directory.
+wp-test-runner/
+
+# Files related to applying patches
+*.rej
+*.orig
+*.patch
+*.diff


### PR DESCRIPTION
This adds several patterns to the `.gitignore` file to prevent accidentally committing files related to contributing through version control.

The `wp-test-runner` directory is also being added as the default directory for running tests locally.