### PR TITLE
Remove unused WPT_CERTIFICATE_VALIDATION environment variable

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -63,7 +63,6 @@ function check_required_env( $check_db = true ) {
  *                                                   inner blocks were found.
  *          @type string $WPT_RM_TEST_DIR_CMD        Command for removing the test directory.
  *          @type string $WPT_REPORT_API_KEY         API key for submitting test results.
- *          @type bool   $WPT_CERTIFICATE_VALIDATION Whether to validate TLS certificates. Default true.
  *          @type bool   $WPT_DEBUG_MODE             Whether debug mode is enabled.
  *      }
  *  }
@@ -74,15 +73,7 @@ function setup_runner_env_vars() {
 		'WPT_TEST_DIR' => trim( getenv( 'WPT_TEST_DIR' ) ) ?: '/tmp/wp-test-runner',
 	);
 
-	/*
-	 * When no value is provided for WPT_CERTIFICATE_VALIDATION, assume that the default of true (validate certificates)
-	 * is desired.
-	 */
-	if ( false === getenv( 'WPT_CERTIFICATE_VALIDATION' ) ) {
-		$runner_configuration['WPT_CERTIFICATE_VALIDATION'] = true;
-	} else {
-		$runner_configuration['WPT_CERTIFICATE_VALIDATION'] = (bool) getenv( 'WPT_CERTIFICATE_VALIDATION' );
-	}
+
 
 	return array_merge(
 		$runner_configuration,

--- a/prepare.php
+++ b/prepare.php
@@ -68,14 +68,6 @@ if ( ! empty( $WPT_SSH_PRIVATE_KEY_BASE64 ) ) {
 
 }
 
-/**
- * Don't validate the TLS certificate
- * Useful for local environments
- */
-$certificate_validation = '';
-if( ! $runner_vars['WPT_CERTIFICATE_VALIDATION'] ) {
-	$certificate_validation .= ' --no-check-certificate';
-}
 
 /**
  * Performs a series of operations to set up the test environment. This includes creating a preparation directory,


### PR DESCRIPTION
- Remove dead code related to WPT_CERTIFICATE_VALIDATION in prepare.php
- Remove WPT_CERTIFICATE_VALIDATION processing from setup_runner_env_vars()
- Update PHPDoc to reflect removed functionality
- Fixes issue #265 where environment variable was processed but never used