### PR TITLE
Report database server version instead of client binary version

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -311,9 +311,174 @@ function upload_results( $results, $rev, $message, $env, $api_key ) {
 }
 
 /**
+ * Parse a WordPress-style database host into mysqli connection pieces.
+ *
+ * @param string $host Database host string.
+ *
+ * @return array|false Parsed connection pieces, or false on invalid input.
+ */
+function wpt_runner_parse_db_host( $host ) {
+	$host = (string) $host;
+	$socket = null;
+	$port = null;
+	$is_ipv6 = false;
+
+	if ( '' === $host ) {
+		return false;
+	}
+
+	$socket_pos = strpos( $host, ':/' );
+	if ( false !== $socket_pos ) {
+		$socket = substr( $host, $socket_pos + 1 );
+		$host = substr( $host, 0, $socket_pos );
+	}
+
+	if ( substr_count( $host, ':' ) > 1 ) {
+		if ( 1 !== preg_match( '/^(?:\[(?P<host>[0-9a-fA-F:.]+)\](?::(?P<port>[0-9]+))?|(?P<host_unbracketed>[0-9a-fA-F:.]+))$/', $host, $matches ) ) {
+			return false;
+		}
+		$parsed_host = ! empty( $matches['host'] ) ? $matches['host'] : ( isset( $matches['host_unbracketed'] ) ? $matches['host_unbracketed'] : '' );
+		$is_ipv6 = true;
+	} else {
+		if ( 1 !== preg_match( '/^(?P<host>[^:]*)(?::(?P<port>[0-9]+))?$/', $host, $matches ) ) {
+			return false;
+		}
+		$parsed_host = $matches['host'];
+	}
+
+	if ( '' === $parsed_host ) {
+		return false;
+	}
+
+	if ( isset( $matches['port'] ) && '' !== $matches['port'] ) {
+		$port = (int) $matches['port'];
+	}
+
+	return array(
+		'host'    => $parsed_host,
+		'port'    => $port,
+		'socket'  => $socket,
+		'is_ipv6' => $is_ipv6,
+	);
+}
+
+/**
+ * Gets the database server version, if it can be detected safely.
+ *
+ * @param string $db_host     Database host.
+ * @param string $db_user     Database user.
+ * @param string $db_password Database password.
+ * @param string $db_name     Database name.
+ *
+ * @return string Raw server version string, or an empty string.
+ */
+function wpt_runner_get_db_server_version( $db_host, $db_user, $db_password, $db_name ) {
+	$db_host = trim( (string) $db_host );
+	$db_user = trim( (string) $db_user );
+	$db_password = (string) $db_password;
+	$db_name = trim( (string) $db_name );
+
+	if ( '' === $db_host ) {
+		$db_host = 'localhost';
+	}
+
+	if ( '' === $db_user || '' === $db_name ) {
+		return '';
+	}
+
+	if ( ! class_exists( 'mysqli' ) ) {
+		return '';
+	}
+
+	$required_functions = array(
+		'mysqli_close',
+		'mysqli_fetch_row',
+		'mysqli_free_result',
+		'mysqli_init',
+		'mysqli_options',
+		'mysqli_query',
+		'mysqli_real_connect',
+	);
+
+	foreach ( $required_functions as $function_name ) {
+		if ( ! function_exists( $function_name ) ) {
+			return '';
+		}
+	}
+
+	$parsed_host = wpt_runner_parse_db_host( $db_host );
+	if ( false === $parsed_host ) {
+		return '';
+	}
+	$connect_host = $parsed_host['host'];
+	// mysqlnd expects IPv6 hosts in brackets, matching WordPress core's connection handling.
+	if ( $parsed_host['is_ipv6'] && extension_loaded( 'mysqlnd' ) ) {
+		$connect_host = '[' . $connect_host . ']';
+	}
+
+	$mysqli = null;
+	$mysqli_report_mode = null;
+
+	try {
+		if ( class_exists( 'mysqli_driver' ) ) {
+			$mysqli_driver = new mysqli_driver();
+			$mysqli_report_mode = $mysqli_driver->report_mode;
+		}
+
+		if ( function_exists( 'mysqli_report' ) ) {
+			mysqli_report( MYSQLI_REPORT_OFF );
+		}
+
+		$mysqli = mysqli_init();
+		if ( false === $mysqli ) {
+			return '';
+		}
+
+		if ( defined( 'MYSQLI_OPT_CONNECT_TIMEOUT' ) ) {
+			mysqli_options( $mysqli, MYSQLI_OPT_CONNECT_TIMEOUT, 5 );
+		}
+
+		if ( ! @mysqli_real_connect(
+			$mysqli,
+			$connect_host,
+			$db_user,
+			$db_password,
+			$db_name,
+			$parsed_host['port'],
+			$parsed_host['socket']
+		) ) {
+			return '';
+		}
+
+		$result = @mysqli_query( $mysqli, 'SELECT VERSION()' );
+		if ( ! is_object( $result ) ) {
+			return '';
+		}
+
+		$row = mysqli_fetch_row( $result );
+		mysqli_free_result( $result );
+
+		if ( ! is_array( $row ) || ! isset( $row[0] ) || '' === (string) $row[0] ) {
+			return '';
+		}
+
+		return (string) $row[0];
+	} catch ( Throwable $e ) {
+		return '';
+	} finally {
+		if ( $mysqli instanceof mysqli ) {
+			@mysqli_close( $mysqli );
+		}
+		if ( null !== $mysqli_report_mode && function_exists( 'mysqli_report' ) ) {
+			mysqli_report( $mysqli_report_mode );
+		}
+	}
+}
+
+/**
  * Collects and returns an array of key environment details relevant to the application's context. This includes
  * the PHP version, installed PHP modules with their versions, system utilities like curl and OpenSSL versions,
- * MySQL version, and operating system details. This function is useful for diagnostic purposes, ensuring
+ * database server version, and operating system details. This function is useful for diagnostic purposes, ensuring
  * compatibility, or for reporting system configurations in debugging or error logs.
  *
  * The function checks for the availability of specific PHP modules and system utilities and captures their versions.
@@ -324,12 +489,12 @@ function upload_results( $results, $rev, $message, $env, $api_key ) {
  *               - 'php_version': The current PHP version.
  *               - 'php_modules': An associative array of selected PHP modules and their versions.
  *               - 'system_utils': Versions of certain system utilities such as 'curl', 'imagemagick', 'graphicsmagick', and 'openssl'.
- *               - 'mysql_version': The version of MySQL installed.
+ *               - 'mysql_version': The version of the database server.
  *               - 'os_name': The name of the operating system.
  *               - 'os_version': The version of the operating system.
  *
  * @uses phpversion() to get the PHP version and module versions.
- * @uses shell_exec() to execute system commands for retrieving MySQL version, OS details, and versions of utilities like curl and OpenSSL.
+ * @uses shell_exec() to execute system commands for retrieving OS details and versions of utilities like curl and OpenSSL.
  * @uses class_exists() to check for the availability of the Imagick and Gmagick classes for version detection.
  */
 function get_env_details() {
@@ -343,12 +508,23 @@ function get_env_details() {
 		$imagick_info = Imagick::queryFormats();
 	}
 
+	$WPT_DB_HOST = trim( getenv( 'WPT_DB_HOST' ) );
+	if( ! $WPT_DB_HOST ) {
+		$WPT_DB_HOST = 'localhost';
+	}
+	$WPT_DB_USER = trim( getenv( 'WPT_DB_USER' ) );
+	$WPT_DB_PASSWORD = getenv( 'WPT_DB_PASSWORD' );
+	if( false === $WPT_DB_PASSWORD ) {
+		$WPT_DB_PASSWORD = '';
+	}
+	$WPT_DB_NAME = trim( getenv( 'WPT_DB_NAME' ) );
+
 	$env = array(
 		'php_version'    => phpversion(),
 		'php_modules'    => array(),
 		'gd_info'        => $gd_info,
 		'imagick_info'   => $imagick_info,
-		'mysql_version'  => trim( shell_exec( 'mysql --version' ) ),
+		'mysql_version'  => wpt_runner_get_db_server_version( $WPT_DB_HOST, $WPT_DB_USER, $WPT_DB_PASSWORD, $WPT_DB_NAME ),
 		'system_utils'   => array(),
 		'os_name'        => trim( shell_exec( 'uname -s' ) ),
 		'os_version'     => trim( shell_exec( 'uname -r' ) ),
@@ -399,18 +575,6 @@ function get_env_details() {
 	function curl_selected_bits($k) { return in_array($k, array('version', 'ssl_version', 'libz_version')); }
 	$curl_bits = curl_version();
 	$env['system_utils']['curl'] = implode(' ',array_values(array_filter($curl_bits, 'curl_selected_bits',ARRAY_FILTER_USE_KEY) ));
-
-	$WPT_DB_HOST		 	= trim( getenv( 'WPT_DB_HOST' ) );
-	if( ! $WPT_DB_HOST ) {
-		$WPT_DB_HOST = 'localhost';
-	}
-	$WPT_DB_USER 			= trim( getenv( 'WPT_DB_USER' ) );
-	$WPT_DB_PASSWORD 	= trim( getenv( 'WPT_DB_PASSWORD' ) );
-	$WPT_DB_NAME 			= trim( getenv( 'WPT_DB_NAME' ) );
-
-	//$mysqli = new mysqli( $WPT_DB_HOST, $WPT_DB_USER, $WPT_DB_PASSWORD, $WPT_DB_NAME );
-	//$env['mysql_version'] = $mysqli->query("SELECT VERSION()")->fetch_row()[0];
-	//$mysqli->close();
 
 	if ( class_exists( 'Imagick' ) ) {
 		$imagick = new Imagick();

--- a/prepare.php
+++ b/prepare.php
@@ -102,36 +102,186 @@ $contents = file_get_contents( $runner_vars['WPT_PREPARE_DIR'] . '/wp-tests-conf
  * Prepares a script to log system information relevant to the testing environment.
  * The script checks for the existence of the log directory and creates it if it does not exist.
  * It then collects various pieces of system information including PHP version, loaded PHP modules,
- * MySQL version, operating system details, and versions of key utilities like cURL and OpenSSL.
+ * database server version, operating system details, and versions of key utilities like cURL and OpenSSL.
  * This information is collected in an array and written to a JSON file in the log directory.
  * Additionally, if running from the command line during a WordPress installation process, 
  * it outputs the PHP version and executable path.
  */
-$system_logger = <<<EOT
+$system_logger = <<<'EOT'
 // Create the log directory to store test results
 if ( ! is_dir(  __DIR__ . '/tests/phpunit/build/logs/' ) ) {
 	mkdir( __DIR__ . '/tests/phpunit/build/logs/', 0777, true );
 }
 // Log environment details that are useful to have reported.
-\$gd_info = array();
+$gd_info = array();
 if( extension_loaded( 'gd' ) ) {
-	\$gd_info = gd_info();
+	$gd_info = gd_info();
 }
-\$imagick_info = array();
+$imagick_info = array();
 if( extension_loaded( 'imagick' ) ) {
-	\$imagick_info = Imagick::queryFormats();
+	$imagick_info = Imagick::queryFormats();
 }
-\$env = array(
+if ( ! function_exists( 'wpt_runner_parse_db_host' ) ) {
+	function wpt_runner_parse_db_host( $host ) {
+		$host = (string) $host;
+		$socket = null;
+		$port = null;
+		$is_ipv6 = false;
+
+		if ( '' === $host ) {
+			return false;
+		}
+
+		$socket_pos = strpos( $host, ':/' );
+		if ( false !== $socket_pos ) {
+			$socket = substr( $host, $socket_pos + 1 );
+			$host = substr( $host, 0, $socket_pos );
+		}
+
+		if ( substr_count( $host, ':' ) > 1 ) {
+			if ( 1 !== preg_match( '/^(?:\[(?P<host>[0-9a-fA-F:.]+)\](?::(?P<port>[0-9]+))?|(?P<host_unbracketed>[0-9a-fA-F:.]+))$/', $host, $matches ) ) {
+				return false;
+			}
+			$parsed_host = ! empty( $matches['host'] ) ? $matches['host'] : ( isset( $matches['host_unbracketed'] ) ? $matches['host_unbracketed'] : '' );
+			$is_ipv6 = true;
+		} else {
+			if ( 1 !== preg_match( '/^(?P<host>[^:]*)(?::(?P<port>[0-9]+))?$/', $host, $matches ) ) {
+				return false;
+			}
+			$parsed_host = $matches['host'];
+		}
+
+		if ( '' === $parsed_host ) {
+			return false;
+		}
+
+		if ( isset( $matches['port'] ) && '' !== $matches['port'] ) {
+			$port = (int) $matches['port'];
+		}
+
+		return array(
+			'host'    => $parsed_host,
+			'port'    => $port,
+			'socket'  => $socket,
+			'is_ipv6' => $is_ipv6,
+		);
+	}
+}
+if ( ! function_exists( 'wpt_runner_get_db_server_version' ) ) {
+	function wpt_runner_get_db_server_version( $db_host, $db_user, $db_password, $db_name ) {
+		$db_host = trim( (string) $db_host );
+		$db_user = trim( (string) $db_user );
+		$db_password = (string) $db_password;
+		$db_name = trim( (string) $db_name );
+
+		if ( '' === $db_host ) {
+			$db_host = 'localhost';
+		}
+
+		if ( '' === $db_user || '' === $db_name ) {
+			return '';
+		}
+
+		if ( ! class_exists( 'mysqli' ) ) {
+			return '';
+		}
+
+		$required_functions = array(
+			'mysqli_close',
+			'mysqli_fetch_row',
+			'mysqli_free_result',
+			'mysqli_init',
+			'mysqli_options',
+			'mysqli_query',
+			'mysqli_real_connect',
+		);
+
+		foreach ( $required_functions as $function_name ) {
+			if ( ! function_exists( $function_name ) ) {
+				return '';
+			}
+		}
+
+		$parsed_host = wpt_runner_parse_db_host( $db_host );
+		if ( false === $parsed_host ) {
+			return '';
+		}
+		$connect_host = $parsed_host['host'];
+		// mysqlnd expects IPv6 hosts in brackets, matching WordPress core's connection handling.
+		if ( $parsed_host['is_ipv6'] && extension_loaded( 'mysqlnd' ) ) {
+			$connect_host = '[' . $connect_host . ']';
+		}
+
+		$mysqli = null;
+		$mysqli_report_mode = null;
+
+		try {
+			if ( class_exists( 'mysqli_driver' ) ) {
+				$mysqli_driver = new mysqli_driver();
+				$mysqli_report_mode = $mysqli_driver->report_mode;
+			}
+
+			if ( function_exists( 'mysqli_report' ) ) {
+				mysqli_report( MYSQLI_REPORT_OFF );
+			}
+
+			$mysqli = mysqli_init();
+			if ( false === $mysqli ) {
+				return '';
+			}
+
+			if ( defined( 'MYSQLI_OPT_CONNECT_TIMEOUT' ) ) {
+				mysqli_options( $mysqli, MYSQLI_OPT_CONNECT_TIMEOUT, 5 );
+			}
+
+			if ( ! @mysqli_real_connect(
+				$mysqli,
+				$connect_host,
+				$db_user,
+				$db_password,
+				$db_name,
+				$parsed_host['port'],
+				$parsed_host['socket']
+			) ) {
+				return '';
+			}
+
+			$result = @mysqli_query( $mysqli, 'SELECT VERSION()' );
+			if ( ! is_object( $result ) ) {
+				return '';
+			}
+
+			$row = mysqli_fetch_row( $result );
+			mysqli_free_result( $result );
+
+			if ( ! is_array( $row ) || ! isset( $row[0] ) || '' === (string) $row[0] ) {
+				return '';
+			}
+
+			return (string) $row[0];
+		} catch ( Throwable $e ) {
+			return '';
+		} finally {
+			if ( $mysqli instanceof mysqli ) {
+				@mysqli_close( $mysqli );
+			}
+			if ( null !== $mysqli_report_mode && function_exists( 'mysqli_report' ) ) {
+				mysqli_report( $mysqli_report_mode );
+			}
+		}
+	}
+}
+$env = array(
 	'php_version'    => phpversion(),
 	'php_modules'    => array(),
-	'gd_info'        => \$gd_info,
-	'imagick_info'   => \$imagick_info,
-	'mysql_version'  => trim( shell_exec( 'mysql --version' ) ),
+	'gd_info'        => $gd_info,
+	'imagick_info'   => $imagick_info,
+	'mysql_version'  => wpt_runner_get_db_server_version( DB_HOST, DB_USER, DB_PASSWORD, DB_NAME ),
 	'system_utils'   => array(),
 	'os_name'        => trim( shell_exec( 'uname -s' ) ),
 	'os_version'     => trim( shell_exec( 'uname -r' ) ),
 );
-\$php_modules = array(
+$php_modules = array(
 	'bcmath',
 	'ctype',
 	'curl',
@@ -168,39 +318,40 @@ if( extension_loaded( 'imagick' ) ) {
 	'zip',
 	'zlib',
 );
-foreach( \$php_modules as \$php_module ) {
-	\$env['php_modules'][ \$php_module ] = phpversion( \$php_module );
+foreach( $php_modules as $php_module ) {
+	$env['php_modules'][ $php_module ] = phpversion( $php_module );
 }
-function curl_selected_bits(\$k) { return in_array(\$k, array('version', 'ssl_version', 'libz_version')); }
-\$curl_bits = curl_version();
-\$env['system_utils']['curl'] = implode(' ',array_values(array_filter(\$curl_bits, 'curl_selected_bits',ARRAY_FILTER_USE_KEY) ));
+function curl_selected_bits($k) { return in_array($k, array('version', 'ssl_version', 'libz_version')); }
+$curl_bits = curl_version();
+$env['system_utils']['curl'] = implode(' ',array_values(array_filter($curl_bits, 'curl_selected_bits',ARRAY_FILTER_USE_KEY) ));
 if ( class_exists( 'Imagick' ) ) {
-	\$imagick = new Imagick();
-	\$version = \$imagick->getVersion();
-	preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', \$version['versionString'], \$version );
-	\$env['system_utils']['imagemagick'] = \$version[1];
+	$imagick = new Imagick();
+	$version = $imagick->getVersion();
+	preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', $version['versionString'], $version );
+	$env['system_utils']['imagemagick'] = $version[1];
 } elseif ( class_exists( 'Gmagick' ) ) {
-	\$gmagick = new Gmagick();
-	\$version = \$gmagick->getversion();
-	preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', \$version['versionString'], \$version );
-	\$env['system_utils']['graphicsmagick'] = \$version[1];
+	$gmagick = new Gmagick();
+	$version = $gmagick->getversion();
+	preg_match( '/Magick (\d+\.\d+\.\d+-\d+|\d+\.\d+\.\d+|\d+\.\d+\-\d+|\d+\.\d+)/', $version['versionString'], $version );
+	$env['system_utils']['graphicsmagick'] = $version[1];
 }
-\$env['system_utils']['openssl'] = str_replace( 'OpenSSL ', '', trim( shell_exec( 'openssl version' ) ) );
-//\$mysqli = new mysqli( WPT_DB_HOST, WPT_DB_USER, WPT_DB_PASSWORD, WPT_DB_NAME );
-//\$env['mysql_version'] = \$mysqli->query("SELECT VERSION()")->fetch_row()[0];
-//\$mysqli->close();
-file_put_contents( __DIR__ . '/tests/phpunit/build/logs/env.json', json_encode( \$env, JSON_PRETTY_PRINT ) );
+$env['system_utils']['openssl'] = str_replace( 'OpenSSL ', '', trim( shell_exec( 'openssl version' ) ) );
+file_put_contents( __DIR__ . '/tests/phpunit/build/logs/env.json', json_encode( $env, JSON_PRETTY_PRINT ) );
 if ( 'cli' === php_sapi_name() && defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 	echo PHP_EOL;
-	echo 'PHP version: ' . phpversion() . ' (' . realpath( \$_SERVER['_'] ) . ')' . PHP_EOL;
+	echo 'PHP version: ' . phpversion() . ' (' . realpath( $_SERVER['_'] ) . ')' . PHP_EOL;
 	echo PHP_EOL;
 }
 EOT;
 
-// Initialize a string that will be used to identify the database settings section in the configuration file.
-$logger_replace_string = '// ** Database settings ** //' . PHP_EOL;
+// Initialize a string that will be used to identify the post-database-settings section in the configuration file.
+$logger_replace_string = 'define( \'DB_COLLATE\', \'\' );' . PHP_EOL;
 
-// Prepend the logger script to the database settings identifier to ensure it gets included in the wp-tests-config.php file.
+if ( false === strpos( $contents, $logger_replace_string ) ) {
+	error_message( 'Unable to insert the system logger after the database constants in wp-tests-config.php.' );
+}
+
+// Append the logger script to the database settings constants to ensure DB_* constants are available.
 $system_logger = $logger_replace_string . $system_logger;
 
 // Define a string that will set the 'WP_PHP_BINARY' constant to the path of the PHP executable.


### PR DESCRIPTION
Fixes 
* New primary issue: https://github.com/WordPress/phpunit-test-runner/issues/318
* Related: https://core.trac.wordpress.org/ticket/58816
* Past attempt: https://github.com/WordPress/phpunit-test-runner/pull/176

## What changed

This updates runner environment collection so `mysql_version` comes from the database server when the runner can detect it safely.

Before this PR, `mysql_version` came from `mysql --version`. That is the local MySQL/MariaDB client binary, not necessarily the database server WordPress used for the test run.

The runner now asks the configured test database for `SELECT VERSION()` and stores the raw value. If that lookup cannot run safely, it leaves `mysql_version` empty and lets the existing reporter display `Unknown`.

I kept the existing `mysql_version` key for reporter compatibility. The field name is not ideal, but changing it would turn this into a runner + reporter data migration. I do not think we need that for this fix.

## Why

As noted in https://github.com/WordPress/phpunit-test-runner/issues/318, Host Test Results labels this value as "Database Version". When it starts with `mysql Ver ...`, it is showing the client program installed where the runner ran. That is not the server WordPress tested against.

This is important when comparing MySQL and MariaDB results, or when a failure only appears on one server version. The report should point to the server. The client, as is currently reported, is not useful.

Before this PR, generated env data could contain a value shaped like:

`mysql Ver 15.1 Distrib 10.11.11-MariaDB`

With this branch, a [live submitted report](https://make.wordpress.org/hosting/test-results/r62456/wpcombot-r62456-8-5-11-4-8-mariadb-log/) shows:

`11.4.8-MariaDB-log`

## History

There has been some previous work around this:

- https://github.com/WordPress/phpunit-test-runner/issues/29 requested
  MySQL/MariaDB version capture.
- https://github.com/WordPress/phpunit-test-runner/pull/32 added the current
  `mysql_version` path using `mysql --version`.
- https://github.com/WordPress/phpunit-test-runner/pull/176 attempted to switch
  this field to `SELECT VERSION()`.
- https://github.com/WordPress/phpunit-test-runner/pull/209 restored the old
  client-version fetch after the server lookup reportedly broke tests. Unfotunately, no errors or details were provided about what broke.
- https://core.trac.wordpress.org/ticket/58816 is related MariaDB context and
  points back to this runner behavior.

This PR keeps the goal from #176. If detection fails, the runner reports `Unknown` through the existing reporter behavior. It should not block the test run, and it should not fall back to the client string as it's not appropriate or useful.

## Avoiding previous issues

The prior attempt's lookup might have been too direct. A failed connection, failed query, missing `mysqli`, empty result row, or PHP 8.1+ `mysqli` exception could cause the test to fail.

This version has more guards

- It checks for `mysqli` support before using it.
- It turns `mysqli` strict reporting off for the lookup and restores the
  previous report mode afterward.
- It uses `mysqli_real_connect()` with parsed host, port, socket, and IPv6
  values.
- It checks the connection, query result, and returned row before using them.
- It frees the result and closes the connection.
- It returns an empty string on failure.

The generated logger in `prepare.php` is still self-contained but it now runs after the generated DB constants exist. The report fallback in `functions.php` uses the same behavior.

I intentionally did not add vendor parsing, normalization, a client-version field, reporter changes, or a replacement field. The key stays `mysql_version` and only the value it reports changes to be the proper server value.

## Testing results
Live report proof:

https://make.wordpress.org/hosting/test-results/r62456/wpcombot-r62456-8-5-11-4-8-mariadb-log/

That report shows Database Version as `11.4.8-MariaDB-log`, matching the server version returned by the live database rather than a `mysql Ver ...` client string.

Compare that to the client versions seen in the rest of the rest results run. The other results still show client values, so the difference is visible in context. https://make.wordpress.org/hosting/test-results/r62456/


## Validation

After hosts update their runner checkout, I would spot-check the next few Host Test Results:

- "Database Version" should show raw server strings such as `8.0.x`,
  `10.x-MariaDB`, or `11.x-MariaDB-log`.
- New reports should not show `mysql Ver ...` under "Database Version".
- Environments where detection cannot run should still show `Unknown`.


## Reminders / follow-up

- This should address the runner-side problem tracked in Core Trac:
  https://core.trac.wordpress.org/ticket/58816
  After this lands, that Trac ticket can be updated or closed as appropriate.
- https://github.com/WordPress/phpunit-test-runner/issues/135 remains related
  for report-only flows that may need an explicit DB-version input when DB
  credentials are not available.
- README  and Hosting handbook examples can be updated if this is merged.