### PR TITLE
Force removal of test directories in cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ export WPT_PHP_EXECUTABLE=${WPT_PHP_EXECUTABLE-php}
 export WPT_PHPUNIT_CMD=""
 
 # (Optionally) define the command execution to remove the test directory
-# Use if `rm -r` can't be called directly for some reason.
+# Use if `rm -rf` can't be called directly for some reason. Include the `-f`
+# flag, or removal stops to ask about write-protected files such as git objects.
 export WPT_RM_TEST_DIR_CMD=""
 
 # SSH connection string (can also be an alias).
@@ -358,7 +359,7 @@ export WPT_PHPUNIT_CMD=""
 
 **Remove directory command**
 
-(Optionally) define the command execution to remove the test directory. Use if `rm -r` can't be called directly for some reason.
+(Optionally) define the command execution to remove the test directory. Use if `rm -rf` can't be called directly for some reason. Include the `-f` flag, or removal stops to ask about write-protected files such as git objects, and cleanup waits for input that never arrives.
 
 ```
 export WPT_RM_TEST_DIR_CMD=""

--- a/cleanup.php
+++ b/cleanup.php
@@ -37,13 +37,13 @@ $runner_vars = setup_runner_env_vars();
  * The following actions are performed:
  * - Forcefully deletes only the .git directory and the node_modules cache.
  * - Forcefully remove the `node_modules/.cache` directory.
- * - Remove the entire preparation directory.
+ * - Forcefully remove the entire preparation directory.
  */
 perform_operations(
 	array(
 		'rm -rf ' . escapeshellarg( $runner_vars['WPT_PREPARE_DIR'] . '/.git' ),
 		'rm -rf ' . escapeshellarg( $runner_vars['WPT_PREPARE_DIR'] . '/node_modules/.cache' ),
-		'rm -r ' . escapeshellarg( $runner_vars['WPT_PREPARE_DIR'] ),
+		'rm -rf ' . escapeshellarg( $runner_vars['WPT_PREPARE_DIR'] ),
 	)
 );
 

--- a/functions.php
+++ b/functions.php
@@ -87,7 +87,7 @@ function setup_runner_env_vars() {
 			'WPT_SSH_CONNECT'     => trim( getenv( 'WPT_SSH_CONNECT' ) ),
 			'WPT_SSH_OPTIONS'     => '' !== $ssh_options ? $ssh_options : '-o StrictHostKeyChecking=no',
 			'WPT_PHP_EXECUTABLE'  => '' !== $php_exec ? $php_exec : 'php',
-			'WPT_RM_TEST_DIR_CMD' => '' !== $rm_test_dir ? $rm_test_dir : 'rm -r ' . $runner_configuration['WPT_TEST_DIR'],
+			'WPT_RM_TEST_DIR_CMD' => '' !== $rm_test_dir ? $rm_test_dir : 'rm -rf ' . escapeshellarg( $runner_configuration['WPT_TEST_DIR'] ),
 			'WPT_REPORT_API_KEY'  => trim( getenv( 'WPT_REPORT_API_KEY' ) ),
 			'WPT_DEBUG'           => (bool) getenv( 'WPT_DEBUG' ),
 		)


### PR DESCRIPTION
Fixes #301

`cleanup.php` removes the preparation directory with `rm -r`. Without `-f`, `rm` stops to ask about write-protected files such as the read-only objects in a nested git checkout, and cleanup waits for input that never arrives. The two commands beside it already use `rm -rf`, so the missing flag looks like an oversight.

## Changes

- `cleanup.php`: remove the preparation directory with `rm -rf`, matching its neighbours.
- `functions.php`: the same flag on the default `WPT_RM_TEST_DIR_CMD`, which runs over SSH.
- `functions.php`: that default concatenated `WPT_TEST_DIR` unescaped, so a path with a space became several targets and a path with a semicolon ran a second command on the remote host. It now goes through `escapeshellarg()`. Older than this change, but forcing removal makes it worth closing here.
- `README.md`: both places documenting `WPT_RM_TEST_DIR_CMD` now show `rm -rf`, since anyone who set it by hand still has the original problem.

## Testing

On a directory containing a read-only file, with a terminal attached:

- `rm -r` asks `override r--r--r--...?` and then fails with `Directory not empty`. The directory survives.
- `rm -rf` removes it, no prompt.

`rm -rf` still returns a non-zero exit code on genuine failures, so `perform_operations()` still reports them. One behaviour changes: removing a path that does not exist now succeeds quietly instead of reporting a failure.

`php -l` passes on both changed files, and PHPCS shows the same single pre-existing warning as `master`.

On macOS the prompt reads `override ...?` rather than the `remove write-protected regular file ...?` wording in the report.

## Use of AI Tools

AI assistance: Yes  
Tool(s): Claude Code and Codex  
Used for: Investigation, implementation review, edge-case testing, and PR wording. I reviewed the reasoning and test results, and I take responsibility for the contribution.
