### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported scope
+
+The WordPress PHPUnit Test Runner is the tooling hosting providers use to run the WordPress core test suite and report results. This repository contains those scripts and their GitHub configuration.
+
+This policy covers security-sensitive issues in the code and configuration of this repository. It does not define support for WordPress core, plugins, themes, hosting stacks, server packages, or hosting platforms.
+
+## Reporting vulnerabilities
+
+For WordPress core, plugins, themes, WordPress.org, or the wider WordPress ecosystem, follow the official [WordPress security reporting guidance](https://wordpress.org/about/security/). WordPress core vulnerabilities should be reported through the [WordPress HackerOne program](https://hackerone.com/wordpress).
+
+Do not report exploitable security vulnerabilities in public GitHub issues or pull requests. For a vulnerability in the test runner scripts themselves, use the reporting channels from the official guidance above rather than a public issue, so hosts running the tooling are not exposed before a fix is available.
+
+If the vulnerability is in a hosting platform, server package, or other third-party project, report it to that project or vendor through their security reporting process.
+
+## Other issues
+
+If you find a bug or an insecure default in the test runner that is not an exploitable vulnerability, open a public issue in this repository:
+
+https://github.com/WordPress/phpunit-test-runner/issues
+
+Include the affected script, the behaviour you observed, and any safer replacement you are suggesting. Do not include exploit details or private vulnerability information in public issues.


### PR DESCRIPTION
Fixes #322.

Adapts the security policy the Hosting Team merged in WordPress/hosting-handbook#410, with the scope rewritten for this repository. The runner is executable tooling rather than documentation, so the policy covers the code and configuration here, directs vulnerability reports for the runner scripts to the official WordPress reporting channels instead of public issues, and keeps ordinary bugs in the public issue tracker.

Placed in .github/ so GitHub surfaces it on the repository's Security tab and in vulnerability report flows, matching the other Hosting Tests Team repositories.

## Use of AI Tools

AI assistance: Yes  
Tool(s): Claude Code and Codex  
Used for: Investigation, implementation review, edge-case testing, and PR wording. I reviewed the reasoning and test results, and I take responsibility for the contribution.
